### PR TITLE
feat: Change workflow schedule to run hourly

### DIFF
--- a/.github/workflows/hourly-update.yml
+++ b/.github/workflows/hourly-update.yml
@@ -1,9 +1,9 @@
-name: Daily AI Timeline Update
+name: Hourly AI Timeline Update
 
 on:
   schedule:
-    # Run every day at 7:00 AM PST (15:00 UTC)
-    - cron: '0 15 * * *'
+    # Run every hour
+    - cron: '0 * * * *'
 
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
The AI Timeline Update workflow was previously configured to run daily. This change updates the schedule to run at the beginning of every hour.

The workflow file and its name have been updated to reflect this new frequency.