### PR TITLE
Update configuration and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 The AI Timeline Automation System automatically:
 
-1. **Collects** AI-related news and research from multiple sources (ArXiv, DeepMind Blog, OpenAI Blog, Hugging Face Blog, and more RSS/API feeds)
+1. **Collects** AI-related news and research from multiple sources (DeepMind Blog, OpenAI Blog, Hugging Face Blog, Microsoft AI News, Google AI News, and more curated feeds)
 2. **Deduplicates** similar content to avoid redundancy
 3. **Analyzes** content using AI to determine significance and impact
 4. **Curates** the most important developments based on configurable thresholds
@@ -37,7 +37,6 @@ The AI Timeline Automation System automatically:
 
 ### 🔄 **Multi-Source Data Collection**
 
-- **ArXiv**: Latest AI/ML research papers (cs.AI feed)
 - **DeepMind/OpenAI/Hugging Face Blogs**: Official announcements and research posts
 - **Extensible RSS/API connectors**: Enable or add new feeds in `config/sources.yaml`
 - **Extensible**: Easy to add new data sources
@@ -70,7 +69,7 @@ The AI Timeline Automation System automatically:
 │   Data Sources  │    │   Processing    │    │     Output      │
 ├─────────────────┤    ├─────────────────┤    ├─────────────────┤
 │ • HackerNews    │───▶│ • Collection    │───▶│ • Timeline JSON │
-│ • ArXiv Papers  │    │ • Deduplication │    │ • GitHub PR     │
+│ • Vendor Blogs  │    │ • Deduplication │    │ • GitHub PR     │
 │ • RSS Feeds     │    │ • AI Analysis   │    │ • Notifications │
 └─────────────────┘    │ • Scoring       │    └─────────────────┘
                        │ • Selection     │
@@ -169,13 +168,12 @@ TIMELINE_REPO=username/ai-timeline       # Target repository (owner/repo)
 # Optional Configuration
 MAX_EVENTS_PER_WEEK=3                    # Maximum events to include per week
 SIGNIFICANCE_THRESHOLD=7.0               # Minimum significance score (0-10)
-NEWS_SOURCES=hackernews,arxiv,rss        # Comma-separated source list
+NEWS_SOURCES=hackernews,openai_blog,rss  # Comma-separated source list
 LOG_LEVEL=info                           # Logging level (error|warn|info|debug)
 DRY_RUN=false                           # Set to true for testing without GitHub updates
 
 # Optional API Keys
 HACKERNEWS_API_KEY=...                  # HackerNews API key (if required)
-ARXIV_API_KEY=...                       # ArXiv API key (if required)
 ```
 
 ## 🎮 Usage

--- a/config/sources.yaml
+++ b/config/sources.yaml
@@ -3,11 +3,6 @@ defaults:
   rate_limit_qpm: 30
   timeout_ms: 15000
 sources:
-  - id: arxiv
-    kind: rss
-    url: https://arxiv.org/rss/cs.AI
-    rate_limit_qpm: 30
-    enabled: true
   - id: deepmind_blog
     kind: html
     url: https://deepmind.google/discover/blog/

--- a/docs/OPERATIONS_GUIDE.md
+++ b/docs/OPERATIONS_GUIDE.md
@@ -10,7 +10,7 @@
    - Secrets:
      - `OPENAI_API_KEY`
      - `GIT_TOKEN` (PAT or GitHub App token with contents/pulls scope)
-     - Optional: `HACKERNEWS_API_KEY`, `ARXIV_API_KEY`
+     - Optional: `HACKERNEWS_API_KEY`
    - Repository variables:
      - `TIMELINE_REPO` (e.g., `owner/repo`)
      - Optional: `DRY_RUN`, `LOG_LEVEL`, `SUMMARY_ISSUE_NUMBER`
@@ -64,7 +64,6 @@ npm run update
 - `npm test -- connectors` &mdash; connector contract tests (uses fixtures under `tests/__fixtures__/`).
 
 ## 7. Connector Cheat Sheet
-- **ArXiv (cs.AI RSS)** &mdash; scientific papers feed, enabled by default.
 - **DeepMind Blog** (HTML/JSON-LD) &mdash; handles structured data + article fallback; add fixtures if DeepMind changes layout.
 - **OpenAI Blog** (RSS) &mdash; includes metadata (`source_name: OpenAI Blog`), rate-limited to 20 QPM.
 - **Hugging Face Blog** (RSS) &mdash; enabled feed for community/feature updates.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated descriptions of available news sources, adding Vendor Blogs, Microsoft AI News, and Google AI News.
  - Revised configuration examples: replaced “arxiv” with “openai_blog” in NEWS_SOURCES.
  - Cleaned up operations guidance by removing references to ArXiv and deprecated optional API keys.

- Chores
  - Removed the ArXiv source from the default source configuration.

- Breaking Changes
  - ArXiv is no longer available as a source; users relying on it should update configurations to use supported sources (e.g., openai_blog, vendor blogs).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->